### PR TITLE
Add .dcm file extension

### DIFF
--- a/binary-extensions.json
+++ b/binary-extensions.json
@@ -35,6 +35,7 @@
 	"csv",
 	"cur",
 	"dat",
+	"dcm",
 	"deb",
 	"dex",
 	"djvu",


### PR DESCRIPTION
There are several file types with this extension (https://fileinfo.com/extension/dcm), but they all seem to be binary.